### PR TITLE
Hide dashboard until optimization triggered

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       </div>
 
       <!-- COLUMNA DASHBOARD -->
-      <div class="dashboard-column" id="dashboard">
+      <div class="dashboard-column hidden" id="dashboard">
         <h2>Resultados</h2>
 
         <div class="card">

--- a/js/main.js
+++ b/js/main.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (tickers.length > 20)  { alert('Máximo 20 activos'); return; }
 
     // 2) Mostrar dashboard
-    dashboard.style.display = 'block';
+    dashboard.classList.remove('hidden');
 
     // 3) Ejecutar Python
     const py = await pyodideReady;


### PR DESCRIPTION
## Summary
- hide dashboard until optimization is requested
- remove `hidden` class on optimize instead of manually setting styles

## Testing
- `pytest -q`
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68557d555fe48320ad9cd64c29619f1a