### PR TITLE
Fix param handling in fetch_prices

### DIFF
--- a/python/fetch_prices.py
+++ b/python/fetch_prices.py
@@ -1,6 +1,9 @@
 import yfinance as yf
 import js
-params = js.params.to_py()
+
+# ``params`` se define desde JavaScript via ``py.globals.set('params', ...)``.
+# Convertimos el objeto JS a un dict de Python.
+params = params.to_py()
 
 tickers = params["tickers"]
 freq    = params["freq"]
@@ -23,6 +26,5 @@ stats = {
 }
 
 # Devolver objetos a JS
-import js
 js.stats = stats
 js.returns_df = returns


### PR DESCRIPTION
## Summary
- ensure Python sees the JS-provided params variable

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855c9aca6ec8320842853d6ddf57567